### PR TITLE
Fix warnings for nullable parameters

### DIFF
--- a/src/Contracts/SmartCache.php
+++ b/src/Contracts/SmartCache.php
@@ -72,7 +72,7 @@ interface SmartCache
      *
      * @return \Illuminate\Contracts\Cache\Repository
      */
-    public function store(string $name = null): \Illuminate\Contracts\Cache\Repository;
+    public function store(string|null $name = null): \Illuminate\Contracts\Cache\Repository;
 
     /**
      * Clear all cache keys managed by SmartCache.

--- a/src/Facades/SmartCache.php
+++ b/src/Facades/SmartCache.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static mixed remember(string $key, \DateTimeInterface|\DateInterval|int|null $ttl, \Closure $callback)
  * @method static mixed rememberForever(string $key, \Closure $callback)
  * @method static mixed flexible(string $key, array $durations, \Closure $callback)
- * @method static \Illuminate\Contracts\Cache\Repository store(string $name = null)
+ * @method static \Illuminate\Contracts\Cache\Repository store(string|null $name = null)
  * @method static bool clear()
  * @method static array getManagedKeys()
  * 

--- a/src/SmartCache.php
+++ b/src/SmartCache.php
@@ -188,7 +188,7 @@ class SmartCache implements SmartCacheContract
     /**
      * {@inheritdoc}
      */
-    public function store(string $name = null): Repository
+    public function store(string|null $name = null): Repository
     {
         if ($name === null) {
             return $this->cache;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -115,7 +115,7 @@ abstract class TestCase extends OrchestraTestCase
     /**
      * Get a specific cache store for testing.
      */
-    protected function getCacheStore(string $store = null)
+    protected function getCacheStore(string|null $store = null)
     {
         return $this->getCacheManager()->store($store);
     }


### PR DESCRIPTION
# Pull Request

## Description
When using the package I receive warnings because the `$key` defaults to `null` but is defined as `string` only.

```
DEPRECATED  SmartCache\SmartCache::store(): Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead in vendor/iazaran/smart-cache/src/SmartCache.php on line 191.

DEPRECATED  SmartCache\Contracts\SmartCache::store(): Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead in vendor/iazaran/smart-cache/src/Contracts/SmartCache.php on line 75.
```

Some issue appeared when running the tests:
```
Deprecated: SmartCache\Tests\TestCase::getCacheStore(): Implicitly marking parameter $store as nullable is deprecated, the explicit nullable type must be used instead in /Users/sebastiancordes/Code/GitHub/smart-cache/tests/TestCase.php on line 118
```

Fixes # (issue)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] Check laravel log when using the package
- [X] Check console when running the tests 

**Test Configuration**:
* PHP version: 8.4.1
* Laravel version: 12.26.4

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X Any dependent changes have been merged and published in downstream modules
